### PR TITLE
Supply extra params to notify

### DIFF
--- a/pybrake/notifier.py
+++ b/pybrake/notifier.py
@@ -71,15 +71,15 @@ class Notifier:
     """
     self._filters.append(filter_fn)
 
-  def notify_sync(self, err):
+  def notify_sync(self, err, *, extra=None):
     """Notifies Airbrake about exception.
 
     Under the hood notify is a shortcut for build_notice and send_notice.
     """
-    notice = self.build_notice(err)
+    notice = self.build_notice(err, extra=extra)
     return self.send_notice_sync(notice)
 
-  def build_notice(self, err):
+  def build_notice(self, err, *, extra=None):
     """Builds Airbrake notice from the exception."""
     notice = dict(
       errors=self._build_errors(err),
@@ -87,6 +87,7 @@ class Notifier:
       params=dict(
         sys_executable=sys.executable,
         sys_path=sys.path,
+        **{} if extra is None else extra
       ),
     )
     return notice
@@ -184,12 +185,12 @@ class Notifier:
     notice['error'] = _ERR_IP_RATE_LIMITED
     return notice
 
-  def notify(self, err):
+  def notify(self, err, *, extra=None):
     """Asynchronously notifies Airbrake about exception from separate thread.
 
     Returns concurrent.futures.Future.
     """
-    notice = self.build_notice(err)
+    notice = self.build_notice(err, extra=extra)
     return self.send_notice(notice)
 
   def send_notice(self, notice):

--- a/pybrake/test_notifier.py
+++ b/pybrake/test_notifier.py
@@ -82,6 +82,16 @@ def test_root_directory():
   assert notice['context']['rootDirectory'] == '/root/dir'
 
 
+def test_notice_extra_params():
+
+  notifier = Notifier()
+
+  notice = notifier.notify_sync('hello', extra=dict(x=10, y=0))
+
+  assert notice['params']['x'] == 10
+  assert notice['params']['y'] == 0
+
+
 def test_filter_data():
   def notifier_filter(notice):
     notice['params']['param'] = 'value'


### PR DESCRIPTION
I believe there should be a way to add extra params specifically for an error you report. 

Notifier.add_filter works well for static parameters like a version of an application, environment variables, etc. 
Another way to do it would be creating new notifier for every single error and adding a filter with local variable through it. But it's not a very good idea since Notifier uses ThreadPoolExecutor and creating the new pool every time would cause big overhead.