### PR TITLE
Allows users to provide a revision to the notifier inititalizer for alternative revision resolution strategies

### DIFF
--- a/pybrake/notifier.py
+++ b/pybrake/notifier.py
@@ -52,7 +52,9 @@ class Notifier:
     self._context = _CONTEXT.copy()
     self._context['rootDirectory'] = kwargs.get('root_directory', os.getcwd())
 
-    rev = get_git_revision(self._context['rootDirectory'])
+    rev = kwargs.get('revision')
+    if rev is None:
+      rev = get_git_revision(self._context['rootDirectory'])
     if rev is not None:
       self._context['revision'] = rev
 


### PR DESCRIPTION
This allows users to provide a `revision` kwarg to the `Notifier` intitializer in the case they have alternative strategies of resolving their revision number. In the case this is not provided, the existing logic is used - ensuring backwards compatibility.

Common use-cases include:

* Not using git, or otherwise identifying their versions differently than a SHA
* Not including the `.git` directory (such as in a docker deployment where extra items are omitted for smaller containers)
* Using Heroku, in which the sha is available in the environment (and not a git directory).

Note, I made a test slightly more generic as the error will appear differently depending on OS.