### PR TITLE
filter setting in Django

### DIFF
--- a/pybrake/notifier.py
+++ b/pybrake/notifier.py
@@ -76,6 +76,9 @@ class Notifier:
         )
         self.add_filter(make_blacklist_filter(keys_blacklist))
 
+        if "filter" in kwargs:
+            self.add_filter(kwargs["filter"])
+
     def close(self):
         if self._thread_pool is not None:
             self._thread_pool.shutdown()


### PR DESCRIPTION
I added an optional param `filter` to `Notifier`'s `__init__`.

By doing this, we can add a custom filter to the global notifiers.

I show an example settings below:

```python
def my_filter(notice):
    if "errors" in notice:
        for i, error in enumerate(notice["errors"]):
            if error['type'] and isinstance(error['type'], django.http.Http404):
                # Do not send django.http.Http404 to Airbrake.
                return None
    return notice

AIRBRAKE = dict(
    project_id=123,
    project_key='FIXME',
    filter=my_filter,
)

#...
```

I hope it makes sense and to be merged.
If there are other suggestions, please let me know, thank you!
