### PR TITLE
Add content-type header check in Django

### DIFF
--- a/pybrake/django.py
+++ b/pybrake/django.py
@@ -52,7 +52,8 @@ class AirbrakeMiddleware:
         response = self.get_response(request)
 
         trace.status_code = response.status_code
-        trace.content_type = response["Content-Type"]
+        if "Content-Type" in response:
+            trace.content_type = response["Content-Type"]
         trace.end_time = time.time()
         self._notifier.routes.notify(trace)
 


### PR DESCRIPTION
# Add content-type header check in Django

In the cases where HTTP header "content-type" is not set, `response["Content-Type"]` raises error like `KeyError: 'content-type'`.
HTTP DELETE method responses may be the case.

So i added the key check before accessing `response["Content-Type"]`.

(Flask integration does not cause this problem since `response.headers.get("Content-Type")` returns the default value when "Content-Type" header doesn't exist.)
https://github.com/airbrake/pybrake/blob/master/pybrake/flask.py#L73

I hope this pull request to be merged, thank you!