### PR TITLE
fixed bug with exception from cython module when source is None

### DIFF
--- a/pybrake/code_hunks.py
+++ b/pybrake/code_hunks.py
@@ -26,7 +26,8 @@ def _get_lines_from_file(filename, loader=None, module_name=None):
         except ImportError:
             pass
         else:
-            return source.splitlines()
+            if source:
+                return source.splitlines()
 
     try:
         with open(filename, "rb") as f:

--- a/pybrake/test_helper.py
+++ b/pybrake/test_helper.py
@@ -51,3 +51,14 @@ def get_nested_exception():
             raise ValueError("world") from err
         except ValueError as err:
             return err
+
+
+def get_exception_in_cython():
+    # accumulation_tree is required by tdigest
+    from accumulation_tree import AccumulationTree  # pylint: disable=import-outside-toplevel
+    t = AccumulationTree(lambda x: x)
+    t.insert(1, '1')
+    try:
+        return t.insert('1', '1')
+    except TypeError as err:
+        return err


### PR DESCRIPTION
There is an issue in `_get_lines_from_file` when error triggered in cython code.
`loader.get_source` from cython file return None object and `source.splitlines()` raise error.
