### PR TITLE
added max_workers to Notifier

### DIFF
--- a/pybrake/notifier.py
+++ b/pybrake/notifier.py
@@ -60,6 +60,7 @@ class Notifier:
         self._rate_limit_reset = 0
         self._max_queue_size = kwargs.get("max_queue_size", 1000)
         self._thread_pool = None
+        self._max_workers = kwargs.get('max_workers')
 
         self._ab_url = _AB_URL_FORMAT.format(host, project_id)
         self._ab_headers = {
@@ -355,8 +356,9 @@ class Notifier:
 
     def _get_thread_pool(self):
         if self._thread_pool is None:
-            max_workers = (os.cpu_count() or 1) * 5
-            self._thread_pool = futures.ThreadPoolExecutor(max_workers=max_workers)
+            if self._max_workers is None:
+                self._max_workers = (os.cpu_count() or 1) * 5
+            self._thread_pool = futures.ThreadPoolExecutor(max_workers=self._max_workers)
         return self._thread_pool
 
 


### PR DESCRIPTION
`os.cpu_count()` return real number of cpu inside docker container with `cpuset`.

And in the case when a node has 40 CPU cores but a container is run with `cpuset=0,19` the `os.cpu_count()` returns 40 but in fact, it has access only to 2 cores.


PS there is a workaround solution, but it works only on Linux:
https://docs.python.org/3/library/os.html#os.sched_getaffinity
```python
max_workers = len(os.sched_getaffinity(0))
```