### PR TITLE
Use a copy of the modules for a thread-safe, non-mutating dict

### DIFF
--- a/pybrake/notifier.py
+++ b/pybrake/notifier.py
@@ -346,7 +346,7 @@ class Notifier:
         ctx = self._context.copy()
 
         versions = ctx["versions"]
-        for name, mod in sys.modules.items():
+        for name, mod in sys.modules.copy().items():
             if name.startswith("_"):
                 continue
             if hasattr(mod, "__version__"):


### PR DESCRIPTION
Resolves #125 

Similar issues were found in the inspect module with regards to certain
imports lazily altering the modules list and causing an iteration to
fail. To avoid this, a copy of the modules dict is used instead.

See: https://bugs.python.org/issue13487