### PR TITLE
Update filter term to "keys_blocklist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ notifier.add_filter(my_filter)
 
 ## Filtering keys
 
-With `keys_blacklist` option you can specify list of keys containing sensitive information that must be filtered out, e.g.:
+With `keys_blocklist` option you can specify list of keys containing sensitive information that must be filtered out, e.g.:
 
 ```python
 notifier = pybrake.Notifier(
     ...
-    keys_blacklist=[
+    keys_blocklist=[
         'password',           # exact match
         re.compile('secret'), # regexp match
     ],

--- a/pybrake/blocklist_filter.py
+++ b/pybrake/blocklist_filter.py
@@ -7,27 +7,27 @@ from .notice import _NOTICE_KEYS
 _FILTERED = "[Filtered]"
 
 
-def make_blacklist_filter(keys_blacklist):
-    def blacklist_filter(notice):
+def make_blocklist_filter(keys_blocklist):
+    def blocklist_filter(notice):
         for key in _NOTICE_KEYS:
             if key in notice:
-                _filter_dict(notice[key], keys_blacklist)
+                _filter_dict(notice[key], keys_blocklist)
         return notice
 
-    return blacklist_filter
+    return blocklist_filter
 
 
-def _filter_dict(d, keys_blacklist):
+def _filter_dict(d, keys_blocklist):
     for key, value in d.items():
-        if _is_blacklisted(key, keys_blacklist):
+        if _is_blocklisted(key, keys_blocklist):
             d[key] = _FILTERED
             continue
         if isinstance(value, collections.abc.Mapping):
-            _filter_dict(value, keys_blacklist)
+            _filter_dict(value, keys_blocklist)
 
 
-def _is_blacklisted(key, keys_blacklist):
-    for k in keys_blacklist:
+def _is_blocklisted(key, keys_blocklist):
+    for k in keys_blocklist:
         if k == key:
             return True
         if _is_regexp(k) and k.match(key):

--- a/pybrake/notifier.py
+++ b/pybrake/notifier.py
@@ -14,7 +14,7 @@ from .git import find_git_dir
 from .routes import _Routes
 from .queries import QueryStats
 from .queues import QueueStats
-from .blacklist_filter import make_blacklist_filter
+from .blocklist_filter import make_blocklist_filter
 from .code_hunks import get_code_hunk
 from .git import get_git_revision
 from .utils import logger
@@ -87,10 +87,14 @@ class Notifier:
             self._context["environment"] = kwargs["environment"]
 
         self.add_filter(pybrake_error_filter)
-        keys_blacklist = kwargs.get(
-            "keys_blacklist", [re.compile("password"), re.compile("secret")]
+        keys_blocklist = kwargs.get(
+            "keys_blocklist",
+            kwargs.get(
+                "keys_blacklist",
+                [re.compile("password"), re.compile("secret")]
+            )
         )
-        self.add_filter(make_blacklist_filter(keys_blacklist))
+        self.add_filter(make_blocklist_filter(keys_blocklist))
 
         if "filter" in kwargs:
             self.add_filter(kwargs["filter"])

--- a/pybrake/notifier.py
+++ b/pybrake/notifier.py
@@ -8,6 +8,7 @@ import urllib.error
 from concurrent import futures
 import json
 import time
+import warnings
 
 from .notice import jsonify_notice
 from .git import find_git_dir
@@ -87,13 +88,21 @@ class Notifier:
             self._context["environment"] = kwargs["environment"]
 
         self.add_filter(pybrake_error_filter)
-        keys_blocklist = kwargs.get(
-            "keys_blocklist",
-            kwargs.get(
-                "keys_blacklist",
-                [re.compile("password"), re.compile("secret")]
-            )
-        )
+
+        keys_blacklist = kwargs.get("keys_blacklist")
+        keys_blocklist = kwargs.get("keys_blocklist")
+
+        if keys_blacklist is not None:
+            keys_blocklist = keys_blacklist
+            warnings.warn(
+                    "keys_blacklist is a deprecated option. "
+                    "Use keys_blocklist instead.",
+                    DeprecationWarning
+                )
+
+        if keys_blocklist is None:
+            keys_blocklist = [re.compile("password"), re.compile("secret")]
+
         self.add_filter(make_blocklist_filter(keys_blocklist))
 
         if "filter" in kwargs:

--- a/pybrake/test_notifier.py
+++ b/pybrake/test_notifier.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from urllib.error import URLError
 
 from .notifier import Notifier
@@ -245,7 +246,14 @@ def _test_keys_blocklist(keys_blocklist):
 
 
 def _test_deprecated_filter_keys(keys_blacklist):
-    notifier = Notifier(keys_blacklist=keys_blacklist)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        notifier = Notifier(keys_blacklist=keys_blacklist)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        deprecation_message = "keys_blacklist is a deprecated option. "\
+                              "Use keys_blocklist instead."
+        assert deprecation_message in str(w[-1].message)
 
     notice = notifier.build_notice("hello")
     notice["params"] = dict(key1="value1", key2="value2", key3=dict(key1="value1"))


### PR DESCRIPTION
Closes: https://github.com/airbrake/pybrake/issues/129

Deprecate use of "blacklist" for filtering term in favor of "blocklist".

## Testing

#### Step 1

Save this simple `example.py` Python program and replace `PROJECT_ID` and `PROJECT_KEY` with those from a real Airbrake project:

```py
import pybrake
import re


notifier = pybrake.Notifier(project_id=PROJECT_ID,
                            project_key=PROJECT_KEY,
                            environment='production',
                            keys_blocklist=['thingo', re.compile('bingo')])

try:
    raise ValueError('hello')
except Exception as err:
    notice = notifier.build_notice(err)
    notice['params']['thingo'] = 'a thing that should be filtered'
    notice['params']['bingo'] = 'another thing that should be filtered'
    notifier.send_notice(notice)
```

#### Step 2 

Install this branch:

```sh
pip install git+https://github.com/airbrake/pybrake.git@update-terms
```

#### Step 3

Run it! 

```sh
python example.py
```

### Step 4

Change `keys_blocklist` to the now deprecated `keys_blacklist` and re-run the program and observe that the params are still filtered.