### PR TITLE
README: mention how to install all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ notifier.queues.notify(metric)
 ### Running the tests
 
 ```shell
+pip install -r requirements.txt
 pip install -r test-requirements.txt
 pytest
 ```


### PR DESCRIPTION
We need this because otherwise dependencies such as tdigest won't be installed.