### PR TITLE
remote_settings: fix fetching config route

### DIFF
--- a/pybrake/settings_data.py
+++ b/pybrake/settings_data.py
@@ -17,6 +17,9 @@ class SettingsData:
         self._project_id = project_id
         self._data = data
 
+    def merge(self, other_data):
+        self._data = {**self._data, **other_data}
+
     def interval(self):
         poll_sec = self._data.get("poll_sec")
         if poll_sec is None:

--- a/pybrake/test_settings_data.py
+++ b/pybrake/test_settings_data.py
@@ -156,3 +156,12 @@ def test_apm_host_when_the_apm_setting_is_missing():
         "settings": [],
     })
     assert s.apm_host() is None
+
+def test_merge():
+    s = SettingsData(1, {
+        "settings": [{"foo": 1}],
+    })
+    s.merge({"settings": [{"foo": 2}]})
+    assert s._data, {
+        "settings": [{"foo": 2}]
+    }


### PR DESCRIPTION
The config route setting has no effect due to a bug where pybrake doesn't read
that value prior to making a GET request to the notifier config server. The fix
is to call `config_route()` on every notifier config GET call.

Additionally, we are adding a logic that prevents remote settings to crash the
background thread in case `config_route` is a bad value (HTTP lib would raise an
error). When an error happens such as 403 Forbidden, we make a 2nd request to
the old config route, which was known to work.