### PR TITLE
Return response when performance_stats is false

### DIFF
--- a/pybrake/flask.py
+++ b/pybrake/flask.py
@@ -111,7 +111,7 @@ def _before_request(config, notifier):
 def _after_request(config, notifier):
     def after_request_middleware(response):
         if not config.get("performance_stats"):
-            return None
+            return response
 
         metric = metrics.get_active()
         if metric is not None:


### PR DESCRIPTION
If the after_request returns null (as is the case when performance_stats is false), flask will throw an exception.  This returns the response unmodified as after_request is meant to.