### PR TITLE
Fixes exception for unhashable type: 'Composed'

### DIFF
--- a/pybrake/queries.py
+++ b/pybrake/queries.py
@@ -132,4 +132,4 @@ class QueryStats:
 
 def query_stat_key(*, query="", method="", route="", time=None):
     time = time // 60 * 60
-    return (query, method, route, time)
+    return (str(query), method, route, time)


### PR DESCRIPTION
Fixes #156 

Forces query hash key to use a str representation of the query

Other types besides string can be passed, such as psycopg2's sql.Sql or sql.Composed classes, which are not hashable.  Turning them to a string makes them hashable

https://www.psycopg.org/docs/sql.html#sql-objects