### PR TITLE
Convert Composed objects into strings when sending query stats

### DIFF
--- a/pybrake/django.py
+++ b/pybrake/django.py
@@ -185,6 +185,8 @@ class CursorWrapper:
         finally:
             end_time = time.time()
             metrics.end_span("sql", end_time=end_time)
+            if hasattr(sql, "as_string"):
+                sql = sql.as_string(self._cursor.cursor)
             self._notifier.queries.notify(
                 query=sql,
                 method=getattr(metric, "method", ""),


### PR DESCRIPTION
Fixes #156. Replaces #157.

This updates pybrake's wrapper `CursorWrapper` to convert SQL Composed
objects into strings before sending query stats to Airbrake. Converting
them to strings will result in better query readability on the
Performance Dashboard. There was also a bug where the notifier would
raise an error because it was not able to process the Composed object.
With this change, that should be fixed.

Big thanks to @mlennon-spr for reporting the bug and presenting the solution!