### PR TITLE
Improve test reliability by cleaning state after running test_celery_integration

### DIFF
--- a/pybrake/test_celery_integration.py
+++ b/pybrake/test_celery_integration.py
@@ -51,3 +51,4 @@ def test_celery_integration():
     assert frame["file"] == "/PROJECT_ROOT/pybrake/test_celery.py"
     assert frame["function"] == "raise_error"
     assert frame["line"] == 16
+    server.socket.close()


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_celery_integration` by cleaning the state before running it.

The test can fail on the second run by running it twice: `pip3 install pytest-repeat; python3 -m pytest --count=2 pybrake/test_celery_integration.py::test_celery_integration`.
```
     def test_celery_integration():
        server_address = ("", 8080)
>       server = HTTPServer(server_address, Handler)

pybrake/test_celery_integration.py:26:
....
        if self.allow_reuse_address:
            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
>       self.socket.bind(self.server_address)
E       OSError: [Errno 98] Address already in use

/usr/lib/python3.8/socketserver.py:466: OSError
```

It may be better to avoid state pollution so that some other tests won't fail in the future due to the shared state pollution (i.e., occupied port).
