### PR TITLE
Fix flaky pybrake/test_celery_integration.py::test_celery_integration

### DIFF
--- a/pybrake/test_celery_integration.py
+++ b/pybrake/test_celery_integration.py
@@ -52,3 +52,5 @@ def test_celery_integration():
     assert frame["function"] == "raise_error"
     assert frame["line"] == 16
     server.socket.close()
+    
+    server.shutdown()


### PR DESCRIPTION
This PR aims to fix `pybrake/test_celery_integration.py::test_celery_integration`. In previous versions, the test will run into failure when running for multiple times. And the reason is that the address `8080` is still occupied, so we can fix it by shut down the server at the end of the test. The test failure can be reproduced by 
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 pybrake/test_celery_integration.py::test_celery_integration`
Notice that the PR is modifying the test to make it more robust without changing the source code.