### PR TITLE
Improvement of backlog appending & sending with Testcases 

### DIFF
--- a/src/pybrake/backlog.py
+++ b/src/pybrake/backlog.py
@@ -7,27 +7,35 @@ from . import metrics
 
 class Backlog(Timer):
     def __init__(self, interval, url, method, header, maxlen=100,
-                 test_backlog_enabled=False, args=None, kwargs=None):
+                 error_notice=False, notifier=None, args=None, kwargs=None):
         super().__init__(interval, self.send, args, kwargs)
         self._backlog = deque(maxlen=maxlen)
         self._url = url
         self._method = method
         self._header = header
-        self._test_backlog_enabled = test_backlog_enabled
+        self._error_notice = error_notice
+        self._notifier = notifier
 
     def send(self):
         # pop out queue items every 1 sec
         # (please ignore empty deque for now)
         while len(self._backlog) > 0:
             payload = self._backlog.popleft()
-            if self._test_backlog_enabled:
-                break
-            metrics.send(url=self._url, headers=self._header,
-                         method=self._method, payload=payload,
-                         backlog=self)
+            if not self._error_notice:
+                metrics.send(url=self._url, headers=self._header,
+                             method=self._method, payload=payload.get('data'),
+                             backlog=self,
+                             retry_count=payload.get('retry_count') + 1
+                             )
+            else:
+                metrics.send_notice(self._notifier, notice=payload.get('data'),
+                                    url=self._url, headers=self._header,
+                                    backlog=self, method=self._method,
+                                    retry_count=payload.get('retry_count')+1
+                                    )
             time.sleep(self.interval)
 
-    def append_stats(self, val):
-        self._backlog.append(val)
+    def append_stats(self, val, retry_count=0):
+        self._backlog.append({'retry_count': retry_count, 'data': val})
         if not self._started.is_set():
             self.start()

--- a/src/pybrake/backlog.py
+++ b/src/pybrake/backlog.py
@@ -6,19 +6,22 @@ from . import metrics
 
 
 class Backlog(Timer):
-    def __init__(self, interval, url, method,
-                 header, maxlen=100, args=None, kwargs=None):
+    def __init__(self, interval, url, method, header, maxlen=100,
+                 test_backlog_enabled=False, args=None, kwargs=None):
         super().__init__(interval, self.send, args, kwargs)
         self._backlog = deque(maxlen=maxlen)
         self._url = url
         self._method = method
         self._header = header
+        self._test_backlog_enabled = test_backlog_enabled
 
     def send(self):
         # pop out queue items every 1 sec
         # (please ignore empty deque for now)
         while len(self._backlog) > 0:
             payload = self._backlog.popleft()
+            if self._test_backlog_enabled:
+                break
             metrics.send(url=self._url, headers=self._header,
                          method=self._method, payload=payload,
                          backlog=self)

--- a/src/pybrake/constant.py
+++ b/src/pybrake/constant.py
@@ -11,6 +11,7 @@ AIRBRAKE_HOST = "https://api.airbrake.io"
 AIRBRAKE_CONFIG_HOST = "https://notifier-configs.airbrake.io"
 
 FLUSH_PERIOD = 15
+MaxRetryAttempt = 3
 
 HTTP_HANDLER = "http.handler"
 

--- a/src/pybrake/notifier.py
+++ b/src/pybrake/notifier.py
@@ -88,6 +88,7 @@ class Notifier:
             "queue_stats": kwargs.get("queue_stats", True),
             "max_backlog_size": kwargs.get("max_backlog_size", 100),
             "backlog_enabled": kwargs.get("backlog_enabled", False),
+            "test_backlog_enabled": kwargs.get("test_backlog_enabled", False),
             "error_host": host,
             "apm_host": host,
         }
@@ -125,13 +126,15 @@ class Notifier:
         self._context["rootDirectory"] = kwargs.get("root_directory",
                                                     os.getcwd())
         self._backlog = None
-        if self.config.get('backlog_enabled'):
+        if self.config.get('backlog_enabled') or\
+                self.config.get('test_backlog_enabled'):
             self._backlog = Backlog(
                 interval=FLUSH_PERIOD,
                 header=self._ab_headers,
                 url=self._ab_url,
                 method="POST",
                 maxlen=self.config.get('max_backlog_size'),
+                test_backlog_enabled=self.config.get('test_backlog_enabled'),
             )
 
         rev = kwargs.get("revision")

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -339,27 +339,13 @@ def test_error_notifications_disabled():
     assert notice["error"] == "error notifications are disabled"
 
 
-def test_notifier_with_backlog_append():
-    notifier = Notifier(test_backlog_enabled=True)
+def test_notifier_with_backlog():
+    notifier = Notifier()
 
     err = get_nested_exception()
     notice = notifier.build_notice(err)
 
     data = jsonify_notice(notice)
-    notifier._backlog.cancel()
     notifier._backlog.append_stats(data)
 
     assert len(notifier._backlog._backlog) == 1
-
-
-def test_notifier_with_backlog_sent():
-    notifier = Notifier(test_backlog_enabled=True)
-
-    err = get_nested_exception()
-    notice = notifier.build_notice(err)
-
-    data = jsonify_notice(notice)
-
-    notifier._backlog.append_stats(data)
-
-    assert len(notifier._backlog._backlog) == 0


### PR DESCRIPTION
Improvements

1. Add threshold for re-sending same data to Airbrake and update data structure accordingly
2. Add data in backlog in response will be in 404, 408, 409, 410, 500, 502, 504