### PR TITLE
[IMP]Backlog feature: 

### DIFF
--- a/src/pybrake/backlog.py
+++ b/src/pybrake/backlog.py
@@ -6,11 +6,10 @@ from . import metrics
 
 
 class Backlog(Timer):
-    def __init__(self, interval, url, method, header, maxlen=100,
+    def __init__(self, method, header, interval=60, maxlen=100,
                  error_notice=False, notifier=None, args=None, kwargs=None):
         super().__init__(interval, self.send, args, kwargs)
         self._backlog = deque(maxlen=maxlen)
-        self._url = url
         self._method = method
         self._header = header
         self._error_notice = error_notice
@@ -22,20 +21,29 @@ class Backlog(Timer):
         while len(self._backlog) > 0:
             payload = self._backlog.popleft()
             if not self._error_notice:
-                metrics.send(url=self._url, headers=self._header,
-                             method=self._method, payload=payload.get('data'),
-                             backlog=self,
-                             retry_count=payload.get('retry_count') + 1
-                             )
+                metrics.send(
+                    url=payload.get('url'),
+                    headers=self._header,
+                    method=self._method,
+                    payload=payload.get('data'),
+                    retry_count=payload.get('retry_count') + 1
+                )
             else:
-                metrics.send_notice(self._notifier, notice=payload.get('data'),
-                                    url=self._url, headers=self._header,
-                                    backlog=self, method=self._method,
-                                    retry_count=payload.get('retry_count')+1
-                                    )
+                metrics.send_notice(
+                    self._notifier,
+                    notice=payload.get('data'),
+                    url=payload.get('url'),
+                    headers=self._header,
+                    method=self._method,
+                    retry_count=payload.get('retry_count') + 1
+                )
             time.sleep(self.interval)
 
-    def append_stats(self, val, retry_count=0):
-        self._backlog.append({'retry_count': retry_count, 'data': val})
+    def append_stats(self, val, url, retry_count=0):
+        self._backlog.append({
+            'retry_count': retry_count,
+            'url': url,
+            'data': val
+        })
         if not self._started.is_set():
             self.start()

--- a/src/pybrake/queries.py
+++ b/src/pybrake/queries.py
@@ -55,13 +55,13 @@ class QueryStats:
         self._stats = None
         self._backlog = None
         if self._config.get('backlog_enabled'):
-            self._backlog = Backlog(
-                interval=constant.FLUSH_PERIOD,
-                header=self._ab_headers,
-                url=self._ab_url(),
-                method="POST",
-                maxlen=self._config.get('max_backlog_size'),
-            )
+            if not metrics.APM_Backlog:
+                metrics.APM_Backlog = Backlog(
+                    header=self._ab_headers,
+                    method="POST",
+                    maxlen=self._config.get('max_backlog_size'),
+                )
+            self._backlog = metrics.APM_Backlog
 
     def notify(
             self, *, query="", method="", route="", start_time=None,
@@ -113,7 +113,6 @@ class QueryStats:
         metrics.send(
             url=self._ab_url(), payload=out,
             headers=self._ab_headers, method="POST",
-            backlog=self._backlog
         )
 
     def _ab_url(self):

--- a/src/pybrake/queues.py
+++ b/src/pybrake/queues.py
@@ -74,13 +74,13 @@ class QueueStats:
         self._stats = None
         self._backlog = None
         if self._config.get('backlog_enabled'):
-            self._backlog = Backlog(
-                interval=constant.FLUSH_PERIOD,
-                header=self._ab_headers,
-                url=self._ab_url(),
-                method="POST",
-                maxlen=self._config.get('max_backlog_size'),
-            )
+            if not metrics.APM_Backlog:
+                metrics.APM_Backlog = Backlog(
+                    header=self._ab_headers,
+                    method="POST",
+                    maxlen=self._config.get('max_backlog_size'),
+                )
+            self._backlog = metrics.APM_Backlog
 
     def notify(self, metric):
         if not self._config.get("performance_stats"):
@@ -130,7 +130,6 @@ class QueueStats:
         metrics.send(
             url=self._ab_url(), headers=self._ab_headers,
             payload=out_json, method="POST",
-            backlog=self._backlog
         )
 
     def _ab_url(self):

--- a/src/pybrake/route_metric.py
+++ b/src/pybrake/route_metric.py
@@ -60,13 +60,13 @@ class RouteBreakdowns:
         self._stats = None
         self._backlog = None
         if self._config.get('backlog_enabled'):
-            self._backlog = Backlog(
-                interval=constant.FLUSH_PERIOD,
-                header=self._ab_headers,
-                url=self._ab_url(),
-                method="POST",
-                maxlen=self._config.get('max_backlog_size'),
-            )
+            if not metrics.APM_Backlog:
+                metrics.APM_Backlog = Backlog(
+                    header=self._ab_headers,
+                    method="POST",
+                    maxlen=self._config.get('max_backlog_size'),
+                )
+            self._backlog = metrics.APM_Backlog
 
     def notify(self, metric):
         if not self._config.get("performance_stats"):
@@ -122,7 +122,6 @@ class RouteBreakdowns:
         metrics.send(
             url=self._ab_url(), payload=out_json,
             headers=self._ab_headers, method="POST",
-            backlog=self._backlog
         )
 
     def _ab_url(self):

--- a/src/pybrake/routes.py
+++ b/src/pybrake/routes.py
@@ -74,13 +74,13 @@ class RouteStats:
         self._stats = None
         self._backlog = None
         if self._config.get('backlog_enabled'):
-            self._backlog = Backlog(
-                interval=constant.FLUSH_PERIOD,
-                header=self._ab_headers,
-                url=self._ab_url(),
-                method="POST",
-                maxlen=self._config.get('max_backlog_size'),
-            )
+            if not metrics.APM_Backlog:
+                metrics.APM_Backlog = Backlog(
+                    header=self._ab_headers,
+                    method="POST",
+                    maxlen=self._config.get('max_backlog_size'),
+                )
+            self._backlog = metrics.APM_Backlog
 
     def notify(self, metric):
         if not self._config.get("performance_stats"):
@@ -133,7 +133,6 @@ class RouteStats:
         metrics.send(
             url=self._ab_url(), headers=self._ab_headers,
             method="POST", payload=out,
-            backlog=self._backlog
         )
 
     def _ab_url(self):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -349,6 +349,6 @@ def test_notifier_with_backlog():
     notice = notifier.build_notice(err)
 
     data = jsonify_notice(notice)
-    notifier._backlog.append_stats(data)
+    notifier._backlog.append_stats(data, notifier._ab_url)
 
     assert len(notifier._backlog._backlog) == 1


### PR DESCRIPTION
Receives notices and APM events and periodically sends them asynchronously in the background (1 minutes). Up to 100 backlog items for notice and APM are Performance (Shared with Routes, Route breakdown, query, queue stats). In the event that the backlog queue becomes full, the item will be replace and an error will be recorded.