### PR TITLE
Show proper error message which API gives 429 response

### DIFF
--- a/src/pybrake/notifier.py
+++ b/src/pybrake/notifier.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import re
@@ -253,8 +254,8 @@ class Notifier:
             return notice
 
         self._rate_limit_reset = time.time() + delay
-
-        notice["error"] = _ERR_IP_RATE_LIMITED
+        data = json.loads(resp.read().decode("utf-8"))
+        notice["error"] = data['message']
         return notice
 
     def notify(self, err):

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -67,11 +67,14 @@ def get_exception_in_cython():
 
 class MockResponse(object):
 
-    def __init__(self, resp_data, code=200, msg='OK'):
+    def __init__(self, resp_data, code=200, headers=None, msg='OK'):
+        if headers is None:
+            headers = {}
         self.resp_data = resp_data
         self.code = code
         self.msg = msg
         self.headers = {'content-type': 'text/plain; charset=utf-8'}
+        self.headers.update(headers)
 
     def read(self):
         if self.resp_data == "IOError":

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -5,8 +5,9 @@ from urllib.error import URLError
 from pybrake.notifier import Notifier
 from pybrake.notice import jsonify_notice
 from pybrake.utils import time_trunc_minute
-from .test_helper import (get_exception, get_nested_exception,
-                          get_exception_in_cython, build_notice_from_str)
+from .test_helper import (
+    get_exception, get_nested_exception, get_exception_in_cython,
+    build_notice_from_str, MockResponse)
 
 
 def test_build_notice_from_exception():
@@ -309,7 +310,13 @@ def _test_full_queue():
     assert notice["error"] == "queue is full"
 
 
-def _test_rate_limited():
+def test_rate_limited(mocker):
+    resp = MockResponse(resp_data='{"message": "test"}'.encode("utf-8"),
+                        code=429, headers={'X-RateLimit-Delay': 100})
+    mocker.patch(
+        "urllib.request.urlopen",
+        return_value=resp
+    )
     notifier = Notifier()
 
     for _ in range(101):


### PR DESCRIPTION
For the time being, if a response receives a 429 error, it will check to see if X-RateLimit-Delay is present or not in headers. If it is not, it will send the message 'X-RateLimit-Delay header is missing', otherwise it will compute the rate limit and send the static message 'IP is rate limited'.

Need to change:
---------------

Replace the static message that says 'IP is rate limited' with the message that is received from the response body.