### PR TITLE
Solve Python 3.12 and Starlette deprecations

### DIFF
--- a/src/pybrake/middleware/starlette.py
+++ b/src/pybrake/middleware/starlette.py
@@ -5,7 +5,7 @@ import traceback
 import types
 
 from starlette.applications import Starlette
-from starlette.exceptions import ExceptionMiddleware
+from starlette.middleware.exceptions import ExceptionMiddleware
 from starlette.responses import Response
 from starlette.routing import Match
 from starlette.types import Receive, Scope, Send

--- a/src/pybrake/utils.py
+++ b/src/pybrake/utils.py
@@ -1,9 +1,9 @@
 import logging
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 def time_trunc_minute(time):
-    t = datetime.utcfromtimestamp(time).replace(second=0, microsecond=0)
+    t = datetime.fromtimestamp(time, UTC).replace(second=0, microsecond=0)
     return t.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 


### PR DESCRIPTION
My changes:

* `datetime.utcfromtimestamp` is [deprecated in Python 3.12](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) - I fixed the warning with the officially suggested solution.
* Starlette needs the `ExceptionMiddleware` to be imported differently since [0.45.0](https://github.com/Kludex/starlette/releases/tag/0.45.0), 
see Kludex/starlette#2826

It would be nice, if you merge my or similar changes and release a new version of the package. Thanks!

BTW: The test suite seems a bit outdated, I could not get it completely green. My changes are tested nevertheless.