### PR TITLE
`Notifier._build_context()`: `mod.__version__` is outdated

### DIFF
--- a/src/pybrake/notifier.py
+++ b/src/pybrake/notifier.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import os
 import platform
@@ -391,8 +392,10 @@ class Notifier:
         for name, mod in sys.modules.copy().items():
             if name.startswith("_"):
                 continue
-            if hasattr(mod, "__version__"):
-                versions[name] = mod.__version__
+            try:
+                versions[name] = importlib.metadata.version(name)
+            except importlib.metadata.PackageNotFoundError:
+                versions[name] = None
 
         return ctx
 


### PR DESCRIPTION
`Notifier._build_context()`: `mod.__version__` is outdated and leads to warnings with multiple packages:

> UserWarning: The '__version__' attribute is deprecated and will be removed in AAA X.Y. Use feature detection, or `importlib.metadata.version("AAA")`, instead.

I changed it to use `importlib.metadata.version()` instead of `__version__`. It is loosely based on the solution in #269.

See https://peps.python.org/pep-0396/, https://packaging.python.org/en/latest/discussions/versioning/#runtime-version-access, https://packaging.python.org/en/latest/discussions/single-source-version/#single-source-version for background information

Maybe solves #269

It would be nice, if you merge my or similar changes and release a new version of the package. Thanks!